### PR TITLE
Change str2dbl(string) to str2number(string)

### DIFF
--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -173,12 +173,12 @@ MUP_NAMESPACE_START
   //
   //------------------------------------------------------------------------------
 
-  FunStrToDbl::FunStrToDbl()
-    :ICallback(cmFUNC, _T("str2dbl"), 1)
+  FunStrToNumber::FunStrToNumber()
+    :ICallback(cmFUNC, _T("str2number"), 1)
   {}
 
   //------------------------------------------------------------------------------
-  void FunStrToDbl::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
+  void FunStrToNumber::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
   {
     assert(a_iArgc==1);
     string_type in;
@@ -197,14 +197,14 @@ MUP_NAMESPACE_START
   }
 
   //------------------------------------------------------------------------------
-  const char_type* FunStrToDbl::GetDesc() const
+  const char_type* FunStrToNumber::GetDesc() const
   {
-    return _T("str2dbl(s) - Converts the string stored in s into a floating foint value.");
+    return _T("str2number(s) - Converts the string stored in s into a floating foint value.");
   }
 
   //------------------------------------------------------------------------------
-  IToken* FunStrToDbl::Clone() const
+  IToken* FunStrToNumber::Clone() const
   {
-    return new FunStrToDbl(*this);
+    return new FunStrToNumber(*this);
   }
 MUP_NAMESPACE_END

--- a/parser/mpFuncStr.h
+++ b/parser/mpFuncStr.h
@@ -93,14 +93,14 @@ MUP_NAMESPACE_START
   /** \brief Parse string to a floating point value. 
       \ingroup functions  
   */
-  class FunStrToDbl : public ICallback
+  class FunStrToNumber : public ICallback
   {
   public:
-    FunStrToDbl ();
+    FunStrToNumber ();
     virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
     virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;
-  }; // class FunStrToDbl
+  }; // class FunStrToNumber
 MUP_NAMESPACE_END
 
 #endif

--- a/parser/mpPackageStr.cpp
+++ b/parser/mpPackageStr.cpp
@@ -58,7 +58,7 @@ void PackageStr::AddToParser(ParserXBase *pParser)
 
   // Functions
   pParser->DefineFun(new FunStrLen());
-  pParser->DefineFun(new FunStrToDbl());
+  pParser->DefineFun(new FunStrToNumber());
   pParser->DefineFun(new FunStrToUpper());
   pParser->DefineFun(new FunStrToLower());
   pParser->DefineFun(new FunStrConcat());


### PR DESCRIPTION
- [x] Change the name of the function `str2dbl(x)` to `str2number(x)`

This function receives a string as parameter and return the number.

```
str2number("5")
return => 5
```

