### PR TITLE
Add left() and right() functions for string typed values

### DIFF
--- a/parser/mpFuncNonCmplx.cpp
+++ b/parser/mpFuncNonCmplx.cpp
@@ -48,6 +48,12 @@
 
 MUP_NAMESPACE_START
 
+// Auxiliary Functions
+double round(double number, int precision) {
+  int decimals = std::pow(10, precision);
+  return (std::round(number * decimals)) / decimals;
+}
+
 #define MUP_UNARY_FUNC(CLASS, IDENT, FUNC, DESC)                     \
     CLASS::CLASS()                                                   \
     :ICallback(cmFUNC, _T(IDENT), 1)                                 \
@@ -125,11 +131,5 @@ MUP_NAMESPACE_START
     MUP_BINARY_FUNC(FunRoundDecimal, "round_decimal", round, "round_decimal(x, y) - round the x number considering y precision")
     MUP_BINARY_FUNC(FunRemainder,    "remainder", std::remainder,  "remainder(x, y) - IEEE remainder of x / y")
 #undef MUP_BINARY_FUNC
-
-// Auxiliary Functions
-double round(double number, int precision) {
-  int decimals = std::pow(10, precision);
-  return (std::round(number * decimals)) / decimals;
-}
 
 MUP_NAMESPACE_END

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -63,7 +63,7 @@ MUP_NAMESPACE_START
   //------------------------------------------------------------------------------
   const char_type* FunStrConcat::GetDesc() const
   {
-    return _T("concat(s) - Returns the concatenation of two strings s1 and s2.");
+    return _T("concat(s1, s2) - Returns the concatenation of two strings s1 and s2.");
   }
 
   //------------------------------------------------------------------------------
@@ -74,7 +74,73 @@ MUP_NAMESPACE_START
 
   //------------------------------------------------------------------------------
   //
-  // Strlen function
+  // Left function
+  //
+  //------------------------------------------------------------------------------
+
+  FunStrLeft::FunStrLeft()
+    :ICallback(cmFUNC, _T("left"), 2)
+  {}
+
+  //------------------------------------------------------------------------------
+  void FunStrLeft::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int)
+  {
+    string_type str = a_pArg[0]->GetString();
+    int cut = a_pArg[1]->GetInteger();
+
+    str = str.substr(0, cut);
+
+    *ret = (string_type) str;
+  }
+
+  //------------------------------------------------------------------------------
+  const char_type* FunStrLeft::GetDesc() const
+  {
+    return _T("left(s1, x) - Returns the left substring of a string, considering x characters.");
+  }
+
+  //------------------------------------------------------------------------------
+  IToken* FunStrLeft::Clone() const
+  {
+    return new FunStrLeft(*this);
+  }
+
+  //------------------------------------------------------------------------------
+  //
+  // Right function
+  //
+  //------------------------------------------------------------------------------
+
+  FunStrRight::FunStrRight()
+    :ICallback(cmFUNC, _T("right"), 2)
+  {}
+
+  //------------------------------------------------------------------------------
+  void FunStrRight::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int)
+  {
+    string_type str = a_pArg[0]->GetString();
+    int cut = a_pArg[1]->GetInteger();
+
+    str = str.substr(str.size() - cut, str.size());
+
+    *ret = (string_type) str;
+  }
+
+  //------------------------------------------------------------------------------
+  const char_type* FunStrRight::GetDesc() const
+  {
+    return _T("right(s1, x) - Returns the right substring of a string, considering x characters.");
+  }
+
+  //------------------------------------------------------------------------------
+  IToken* FunStrRight::Clone() const
+  {
+    return new FunStrRight(*this);
+  }
+
+  //------------------------------------------------------------------------------
+  //
+  // Length function
   //
   //------------------------------------------------------------------------------
 

--- a/parser/mpFuncStr.h
+++ b/parser/mpFuncStr.h
@@ -38,13 +38,39 @@ MUP_NAMESPACE_START
 
 
   //------------------------------------------------------------------------------
-  /** \brief Callback object for determining the the concatenation of two strings.
+  /** \brief Callback object for determining the concatenation of two strings.
       \ingroup functions
   */
   class FunStrConcat : public ICallback
   {
   public:
     FunStrConcat();
+    virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  };
+
+  //------------------------------------------------------------------------------
+  /** \brief Callback object for determining the left part of a string.
+      \ingroup functions
+  */
+  class FunStrLeft : public ICallback
+  {
+  public:
+    FunStrLeft();
+    virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  };
+
+  //------------------------------------------------------------------------------
+  /** \brief Callback object for determining the right part of a string.
+      \ingroup functions
+  */
+  class FunStrRight : public ICallback
+  {
+  public:
+    FunStrRight();
     virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
     virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;

--- a/parser/mpPackageStr.cpp
+++ b/parser/mpPackageStr.cpp
@@ -62,6 +62,8 @@ void PackageStr::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunStrToUpper());
   pParser->DefineFun(new FunStrToLower());
   pParser->DefineFun(new FunStrConcat());
+  pParser->DefineFun(new FunStrLeft());
+  pParser->DefineFun(new FunStrRight());
 
   // Operators
   pParser->DefineOprt(new OprtStrAdd);

--- a/sample/example.cpp
+++ b/sample/example.cpp
@@ -79,7 +79,7 @@ using namespace mup;
 #if defined(CREATE_LEAKAGE_REPORT)
 
 // Dumping memory leaks in the destructor of the static guard
-// guarantees i won't get false positives from the ParserErrorMsg 
+// guarantees I won't get false positives from the ParserErrorMsg
 // class wich is a singleton with a static instance.
 struct DumpLeaks
 {
@@ -107,43 +107,6 @@ int CheckKeywords(const char_type *a_szLine, ParserXBase &a_Parser)
 
   return 0;
 }
-
-//---------------------------------------------------------------------------
-/** A more readable strings concatenation function.
- *  concat("Hello ", "World")
-*/
-
-// string_type concat(string_type firstString, string_type secondString)
-// {
-//   return firstString + secondString;
-// }
-
-
-// class MySine : public mup::ICallback
-// {
-//   MySine()
-//     :ICallback(cmFUNC, _T("mysin"), 1)
-//   {}
-
-//   virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
-//   {
-//     // Get the argument from the argument input vector
-//     float_type a = a_pArg[0]->GetFloat();
-
-//     // The return value is passed by writing it to the reference ret
-//     *ret = sin(a);
-//   }
-
-//   const char_type* GetDesc() const
-//   {
-//     return "mysin(x) - A custom sine function";
-//   }
-
-//   IToken* Clone() const
-//   {
-//     return new MySine(*this);
-//   }
-// };
 
 //---------------------------------------------------------------------------
 void Calc()


### PR DESCRIPTION
- [x] Add `left(string s, int x)` function. This function returns the left substring of the string `s`, considering the `x` characters.
- [x] Add `right(string s, int x)` function. This function returns the right substring of the string `s`, considering the `x` characters.

See some working examples below...
![screen shot 2018-05-18 at 02 31 28](https://user-images.githubusercontent.com/7637806/40217652-423efd4e-5a44-11e8-93ae-f027add411a6.png)