### PR TITLE
Define long double and use it for 9 precision approximations

### DIFF
--- a/parser/mpDefines.h
+++ b/parser/mpDefines.h
@@ -69,6 +69,10 @@
 /** \brief Floating point type used by the parser. */
 #define MUP_FLOAT_TYPE double
 
+/** \brief Long double type used by the parser for high precision values. */
+#define MUP_LDOUBLE_TYPE long double
+
+/** \brief Integer type used by the parser. */
 #define MUP_INT_TYPE int
 
 /** \brief Verifies whether a given condition is met.

--- a/parser/mpFuncNonCmplx.cpp
+++ b/parser/mpFuncNonCmplx.cpp
@@ -49,8 +49,8 @@
 MUP_NAMESPACE_START
 
 // Auxiliary Functions
-double round(double number, int precision) {
-  int decimals = std::pow(10, precision);
+double round(long_double_type number, int_type precision) {
+  int_type decimals = std::pow(10, precision);
   return (std::round(number * decimals)) / decimals;
 }
 

--- a/parser/mpTypes.h
+++ b/parser/mpTypes.h
@@ -93,7 +93,10 @@ typedef std::vector<ptr_val_type> val_vec_type;
 /** \brief Parser datatype for floating point value. */
 typedef MUP_FLOAT_TYPE float_type;
 
-/** \brief Parser datatype for integer valuse. */
+/** \brief Parser datatype for long double values (for high precision). */
+typedef MUP_LDOUBLE_TYPE long_double_type;
+
+/** \brief Parser datatype for integer values. */
 typedef MUP_INT_TYPE int_type;
 
 /** \brief The basic type used for representing complex numbers. */


### PR DESCRIPTION
- [x] Define long double type to use it in `muparserx`
- [x] Update `round_decimal(number, precision)` function. Now it is possible to round numbers with 9 precision.

Please, check the below example...

![screen shot 2018-05-18 at 14 19 08](https://user-images.githubusercontent.com/7637806/40249396-40943648-5aa9-11e8-858a-2ca338e2d60e.png)
