### PR TITLE
Update README removing invalid operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ A powerful C++ mathematical expression parser library with support for **complex
 | Not Equal | `a != b` | Inequality | `3 != 4 = true` |
 | Logical AND | `a && b`, `a and b` | Logical conjunction | `true && false = false` |
 | Logical OR | `a || b`, `a or b` | Logical disjunction | `true || false = true` |
-| Logical NOT | `!a` | Logical negation | `!true = false` |
 | Bitwise AND | `a & b` | Bitwise conjunction | `5 & 3 = 1` |
 | Bitwise OR | `a | b` | Bitwise disjunction | `5 | 3 = 7` |
 | Left Shift | `a << b` | Bitwise left shift | `1 << 3 = 8` |

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ A powerful C++ mathematical expression parser library with support for **complex
 | Equal | `a == b` | Equality | `3 == 3 = true` |
 | Not Equal | `a != b` | Inequality | `3 != 4 = true` |
 | Logical AND | `a && b`, `a and b` | Logical conjunction | `true && false = false` |
-| Logical OR | `a || b`, `a or b` | Logical disjunction | `true || false = true` |
+| Logical OR | <code>a &#124;&#124; b</code>, <code>a or b</code> | Logical disjunction | <code>true &#124;&#124; false = true</code> |
 | Bitwise AND | `a & b` | Bitwise conjunction | `5 & 3 = 1` |
-| Bitwise OR | `a | b` | Bitwise disjunction | `5 | 3 = 7` |
+| Bitwise OR | <code>a &#124; b</code> | Bitwise disjunction | <code>5 &#124; 3 = 7</code> |
 | Left Shift | `a << b` | Bitwise left shift | `1 << 3 = 8` |
 | Right Shift | `a >> b` | Bitwise right shift | `8 >> 3 = 1` |
 


### PR DESCRIPTION
## Summary
- Fix Markdown table formatting for Logical OR and Bitwise OR operators
- Remove non-existent "Logical NOT" operator from the operators table

## Details
This PR addresses formatting issues in the README's operators table:

1. **Removed Logical NOT operator**: This operator was listed in the table but [doesn't exist in the library's implementation](https://beltoforion.de/en/muparserx/).
2. **Fixed Logical OR operator display**: Changed from plain text `a || b` to HTML entity encoding `<code>a &#124;&#124; b</code>` to prevent Markdown table parsing issues
3. **Fixed Bitwise OR operator display**: Changed from plain text `a | b` to HTML entity encoding `<code>a &#124; b</code>` to prevent Markdown table cell separation issues

